### PR TITLE
Fix for is_1536

### DIFF
--- a/R/plate_map.R
+++ b/R/plate_map.R
@@ -113,6 +113,7 @@ plate_map_multiple <- function(data, well){
 #' @param well vector of alphanumeric well labels
 
 is_1536 <- function(well){
-    # check if contains double character well labels
-    any(nchar(as.character(well)) == 4)
+  # check if contains double character well labels
+  two_letters <- do.call(paste0,expand.grid(LETTERS,LETTERS))
+  any(grepl(paste(two_letters, collapse = '|'), well, ignore.case = TRUE))
 }


### PR DESCRIPTION
The function failed to recognize 1536 well plates when column numbers weren't zero padded  (i.e. `A1` vs `A01`). This is because it was checking if the number of characters in the vector of wells was equal to 4, which it wouldn't be in the case where column numbers aren't zero padded (`AA1` vs `AA01`). This change looks for wells that contain two consecutive letters.